### PR TITLE
fix: 视频合并时下载目录有空格导致报错

### DIFF
--- a/gui/download.py
+++ b/gui/download.py
@@ -139,11 +139,21 @@ class DownloadUtils:
         self.merge_error = False
 
         if self.none_audio:
-            cmd = ["cd", Config.Download.path, "&&", "rename", video_f_name, f"{title}.mp4"]
+            cmd = [
+                "rename", video_f_name, f"{title}.mp4"
+            ]
         else:
-            cmd = ["cd", Config.Download.path, "&&", Config.FFmpeg.path, "-y", "-i", video_f_name, "-i", audio_f_name, "-acodec", "copy", "-vcodec", "copy", "-strict", "experimental", f"{title}.mp4"]
-                
-        self.merge_process = subprocess.Popen(cmd, shell = True, stdout = subprocess.PIPE, stderr = subprocess.STDOUT)
+            cmd = [
+                f'{Config.FFmpeg.path}',
+                "-y",
+                "-i", f'{video_f_name}',
+                "-i", f'{audio_f_name}',
+                "-acodec", "copy",
+                "-vcodec", "copy",
+                "-strict", "experimental",
+                f"{title}.mp4"
+            ]
+        self.merge_process = subprocess.Popen(cmd, shell=True, cwd=Config.Download.path, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         self.merge_process.wait()
         
         if self.merge_process.returncode == 0:


### PR DESCRIPTION
报错信息：
---

ffmpeg version 7.0.1-essentials_build-www.gyan.dev Copyright (c) 2000-2024 the FFmpeg developers  built with gcc 13.2.0 (Rev5, Built by MSYS2 project)  configuration: --enable-gpl --enable-version3 --enable-static --disable-w32threads --disable-autodetect --enable-fontconfig --enable-iconv --enable-gnutls --enable-libxml2 --enable-gmp --enable-bzlib --enable-lzma --enable-zlib --enable-libsrt --enable-libssh --enable-libzmq --enable-avisynth --enable-sdl2 --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxvid --enable-libaom --enable-libopenjpeg --enable-libvpx --enable-mediafoundation --enable-libass --enable-libfreetype --enable-libfribidi --enable-libharfbuzz --enable-libvidstab --enable-libvmaf --enable-libzimg --enable-amf --enable-cuda-llvm --enable-cuvid --enable-dxva2 --enable-d3d11va --enable-d3d12va --enable-ffnvcodec --enable-libvpl --enable-nvdec --enable-nvenc --enable-vaapi --enable-libgme --enable-libopenmpt --enable-libopencore-amrwb --enable-libmp3lame --enable-libtheora --enable-libvo-amrwbenc --enable-libgsm --enable-libopencore-amrnb --enable-libopus --enable-libspeex --enable-libvorbis --enable-librubberband  libavutil      59.  8.100 / 59.  8.100  libavcodec     61.  3.100 / 61.  3.100  libavformat    61.  1.100 / 61.  1.100  libavdevice    61.  1.100 / 61.  1.100  libavfilter    10.  1.100 / 10.  1.100  libswscale      8.  1.100 /  8.  1.100  libswresample   5.  1.100 /  5.  1.100  libpostproc    58.  1.100 / 58.  1.100[in#0 @ 0000025de077f9c0] Error opening input: No such file or directoryError opening input file video_9211.mp4.Error opening input files: No such file or directory