### PR TITLE
下载按钮与用户选择匹配

### DIFF
--- a/src/gui/main.py
+++ b/src/gui/main.py
@@ -728,6 +728,11 @@ class MainWindow(Frame):
         dlg = OptionDialog(self, stream_type, callback)
         dlg.ShowModal()
 
+        if dlg.audio_only_chk.IsChecked():
+            self.download_btn.SetLabel("下载音频")
+        else:
+            self.download_btn.SetLabel("下载视频")
+
     def onEpisodeOptionMenuEVT(self, event):
         def _clear():
             self.treelist.init_list()


### PR DESCRIPTION
如果用户选择了“只下载音频”，那么“下载按钮”的提示变成“下载音频”，以免用户迷糊