### PR TITLE
Support cutting a clip by start and end time

### DIFF
--- a/src/gui/dialog/option.py
+++ b/src/gui/dialog/option.py
@@ -49,9 +49,31 @@ class OptionDialog(wx.Dialog):
         flex_box.Add(self.video_codec_lab, 0, wx.ALL | wx.ALIGN_CENTER, 10)
         flex_box.Add(self.video_codec_choice, 0, wx.ALL & (~wx.LEFT), 10)
 
+        self.time_cut_chk = wx.CheckBox(self, -1, "裁剪音视频时间")
+
+        self.start_time_lab = wx.StaticText(self, -1, "开始时间")
+        self.start_time_text = wx.TextCtrl(self, -1)
+        self.start_time_text.SetHint("HH:MM:SS")
+
+        self.end_time_lab = wx.StaticText(self, -1, "结束时间")
+        self.end_time_text = wx.TextCtrl(self, -1)
+        self.end_time_text.SetHint("HH:MM:SS")
+
+        time_cut_grid = wx.FlexGridSizer(2, 2, 0, 0)
+        time_cut_grid.Add(self.start_time_lab, 0, wx.ALL | wx.ALIGN_CENTER, 10)
+        time_cut_grid.Add(self.start_time_text, 0, wx.ALL & (~wx.LEFT), 10)
+        time_cut_grid.Add(self.end_time_lab, 0, wx.ALL | wx.ALIGN_CENTER, 10)
+        time_cut_grid.Add(self.end_time_text, 0, wx.ALL & (~wx.LEFT), 10)
+
+        time_cut_box = wx.BoxSizer(wx.VERTICAL)
+        time_cut_box.AddSpacer(10)
+        time_cut_box.Add(self.time_cut_chk, 0, wx.LEFT, 10)
+        time_cut_box.Add(time_cut_grid, 0, wx.LEFT, 30)
+
         media_vbox = wx.BoxSizer(wx.VERTICAL)
         media_vbox.Add(flex_box, 0, wx.EXPAND)
         media_vbox.Add(self.audio_only_chk, 0, wx.ALL, 10)
+        media_vbox.Add(time_cut_box, 0, wx.EXPAND)
 
         self.get_danmaku_chk = wx.CheckBox(self, -1, "下载视频弹幕")
         self.danmaku_format_lab = wx.StaticText(self, -1, "弹幕文件格式")
@@ -116,6 +138,7 @@ class OptionDialog(wx.Dialog):
         self.audio_only_chk.Bind(wx.EVT_CHECKBOX, self.onCheckAudioOnlyEVT)
         self.get_danmaku_chk.Bind(wx.EVT_CHECKBOX, self.onCheckDanmakuEVT)
         self.get_subtitle_chk.Bind(wx.EVT_CHECKBOX, self.onCheckSubtitleEVT)
+        self.time_cut_chk.Bind(wx.EVT_CHECKBOX, self.onCheckTimeCutEVT)
 
         self.ok_btn.Bind(wx.EVT_BUTTON, self.onConfirmEVT)
 
@@ -172,6 +195,7 @@ class OptionDialog(wx.Dialog):
         self.onCheckAudioOnlyEVT(0)
         self.onCheckDanmakuEVT(0)
         self.onCheckSubtitleEVT(0)
+        self.onCheckTimeCutEVT(0)
 
     def onCheckAudioOnlyEVT(self, event):
         _enable = not self.audio_only_chk.GetValue()
@@ -195,6 +219,15 @@ class OptionDialog(wx.Dialog):
 
         set_enable(self.get_subtitle_chk.GetValue())
 
+    def onCheckTimeCutEVT(self, event):
+        def set_enable(enable: bool):
+            self.start_time_lab.Enable(enable)
+            self.start_time_text.Enable(enable)
+            self.end_time_lab.Enable(enable)
+            self.end_time_text.Enable(enable)
+
+        set_enable(self.time_cut_chk.GetValue())
+
     def onConfirmEVT(self, event):
         AudioInfo.audio_quality_id = audio_quality_map[self.audio_quality_choice.GetStringSelection()]
         AudioInfo.download_audio_only = self.audio_only_chk.GetValue()
@@ -208,6 +241,8 @@ class OptionDialog(wx.Dialog):
         ExtraInfo.get_cover = self.get_cover_chk.GetValue()
 
         Config.Download.add_number = self.add_number_chk.GetValue()
+        Config.Merge.cut_start_time = self.start_time_text.GetValue()
+        Config.Merge.cut_end_time = self.end_time_text.GetValue()
 
         self.callback(self.video_quality_choice.GetSelection(), self.video_quality_choice.IsEnabled())
 

--- a/src/gui/download_v2.py
+++ b/src/gui/download_v2.py
@@ -680,22 +680,29 @@ class DownloadUtils:
             # 覆盖文件
             if Config.Merge.override_file:
                 UniversalTool.remove_files(Config.Download.path, _file_name_list)
+        start_time = FormatTool.format_cut_time(Config.Merge.cut_start_time)
+        end_time = FormatTool.format_cut_time(Config.Merge.cut_end_time)
+        time_params = ""
+        if start_time:
+            time_params += f' -ss {start_time}'
+        if end_time:
+            time_params += f' -to {end_time}'
 
         def _dash():
             def _get_audio_cmd():
                 match self.task_info.audio_type:
                     case "m4a" | "ec3":
                         if Config.Merge.m4a_to_mp3 and self.task_info.audio_type == "m4a":
-                            return f'"{Config.FFmpeg.path}" -y -i "{self._temp_audio_file_name}" -c:a libmp3lame -q:a 0 "{self.file_title}.mp3"'
+                            return f'"{Config.FFmpeg.path}" -y -i "{self._temp_audio_file_name}" -c:a libmp3lame -q:a 0 {time_params} "{self.file_title}.mp3"'
                         else:
                             return f'{_rename_cmd} "{self._temp_audio_file_name}" {_extra}"{self.full_file_name}"'
                     
                     case "flac":
-                        return f'"{Config.FFmpeg.path}" -y -i "{self._temp_audio_file_name}" -c:a flac -q:a 0 "{self.file_title}.flac"'
+                        return f'"{Config.FFmpeg.path}" -y -i "{self._temp_audio_file_name}" -c:a flac -q:a 0 {time_params} "{self.file_title}.flac"'
             
             match MergeType(self.task_info.video_merge_type):
                 case MergeType.Video_And_Audio:
-                    return f'"{Config.FFmpeg.path}" -y -i "{self._temp_video_file_name}" -i "{self._temp_audio_file_name}" -acodec copy -vcodec copy -strict experimental {self._temp_out_file_name} && {_rename_cmd} {self._temp_out_file_name} {_extra}"{self.full_file_name}"'
+                    return f'"{Config.FFmpeg.path}" -y -i "{self._temp_video_file_name}" -i "{self._temp_audio_file_name}" -acodec copy -vcodec copy -strict experimental {time_params} {self._temp_out_file_name} && {_rename_cmd} {self._temp_out_file_name} {_extra}"{self.full_file_name}"'
 
                 case MergeType.Only_Video:
                     return f'{_rename_cmd} "{self._temp_video_file_name}" {_extra}"{self.full_file_name}"'
@@ -710,7 +717,7 @@ class DownloadUtils:
             
             _generate_flv_list_txt()
 
-            return f'"{Config.FFmpeg.path}" -y -f concat -safe 0 -i {self._temp_flv_list_name} -c copy {self._temp_out_file_name} && {_rename_cmd} {self._temp_out_file_name} {_extra}"{self.full_file_name}"'
+            return f'"{Config.FFmpeg.path}" -y -f concat -safe 0 -i {self._temp_flv_list_name} -c copy {time_params} {self._temp_out_file_name} && {_rename_cmd} {self._temp_out_file_name} {_extra}"{self.full_file_name}"'
 
         match Config.Sys.platform:
             case "windows":

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -86,6 +86,9 @@ class Config:
         m4a_to_mp3: bool = True
         auto_clean: bool = True
 
+        cut_start_time: str = ""
+        cut_end_time: str = ""
+
     class Temp:
         download_window_pos = None
 

--- a/src/utils/tool_v2.py
+++ b/src/utils/tool_v2.py
@@ -398,6 +398,11 @@ class FormatTool:
         else:
             return str(data)
 
+    @staticmethod
+    def format_cut_time(time: str):
+        # 避免中文用户经常误输入
+        return time.replace("：", ":").replace(";",":").replace("；",":")
+
 class UniversalTool:
     # 通用工具类
     @staticmethod


### PR DESCRIPTION
close: #78

Solution:

Adds in time related parameters for FFMPEG command in MERGE process.

I verified the following case:

1. Video: combination of w/ or w/o start time, w/ or w/o end time;
2. Audio Only: combination of w/ or w/o start time, w/ or w/o end time.