### PR TITLE
新粘贴地址后，下载按钮的文字与用户选择一致

### DIFF
--- a/src/gui/main.py
+++ b/src/gui/main.py
@@ -399,7 +399,11 @@ class MainWindow(Frame):
                 case ParseType.Video |  ParseType.Bangumi | ParseType.Cheese:
                     self.episode_option_btn.Enable(True)
                     self.download_option_btn.Enable(True)
-                    self.download_btn.SetLabel("下载视频")
+
+                    if dlg.audio_only_chk.IsChecked():
+                        self.download_btn.SetLabel("下载音频")
+                    else:
+                        self.download_btn.SetLabel("下载视频")
 
                 case ParseType.Live:
                     self.episode_option_btn.Enable(False)


### PR DESCRIPTION
新粘贴地址按”Get“后，”下载按钮“文字变回”下载视频“。本修改，当用户选择了”仅下载音频“时，”下载按钮“文字是”下载音频“。这是对 https://github.com/ScottSloan/Bili23-Downloader/pull/76 的完善

我不清楚，对于直播类的，要不要修改按钮提示。因为目前我没有下载过直播。有需要的朋友自己修改吧