### PR TITLE
🐛 fix: 修复树形列表控件中选中项状态检查的异常情况

### DIFF
--- a/src/gui/component/tree_list_v2.py
+++ b/src/gui/component/tree_list_v2.py
@@ -178,7 +178,9 @@ class TreeListCtrl(wx.dataview.TreeListCtrl):
             self.Expand(item)
 
     def CheckAllItems(self):
-        self.CheckItemRecursively(self.GetRootItem(), wx.CHK_CHECKED)
+        root_item = self.GetRootItem()
+        if root_item.IsOk():
+            self.CheckItemRecursively(root_item, wx.CHK_CHECKED)
 
     def GetAllCheckedItem(self, parse_type: ParseType, video_quality_id: int):
         self.download_task_info_list = []
@@ -198,20 +200,29 @@ class TreeListCtrl(wx.dataview.TreeListCtrl):
     def GetCurrentItemType(self):
         item = self.GetSelection()
 
+        if not item.IsOk():
+            return None
+
         return self.GetItemData(item).item_type
     
     def GetCurrentItemCheckedState(self):
         item = self.GetSelection()
 
+        if not item.IsOk():
+            return False
+
         match self.GetCheckedState(item):
             case wx.CHK_CHECKED | wx.CHK_UNDETERMINED:
                 return True
-            
+
             case wx.CHK_UNCHECKED:
                 return False
 
     def GetCurrentItemCollapsedState(self):
         item = self.GetSelection()
+
+        if not item.IsOk():
+            return True
 
         return not self.IsExpanded(item)
 

--- a/src/utils/common/file_name_v2.py
+++ b/src/utils/common/file_name_v2.py
@@ -126,7 +126,11 @@ class FileNameFormatter:
     
     @staticmethod
     def removeprefix(path: str):
-        while path.startswith("\\"):
-            path = path.removeprefix("\\")
+        # 移除开头的反斜杠和正斜杠，防止创建根目录路径
+        while path.startswith("\\") or path.startswith("/"):
+            if path.startswith("\\"):
+                path = path.removeprefix("\\")
+            elif path.startswith("/"):
+                path = path.removeprefix("/")
 
         return path


### PR DESCRIPTION
🐛 fix: 优化文件名格式化工具，移除路径开头的反斜杠和正斜杠
Fixes #184 