### PR TITLE
单纯下载音频时，是否转换

### DIFF
--- a/src/utils/module/ffmpeg/command.py
+++ b/src/utils/module/ffmpeg/command.py
@@ -18,16 +18,22 @@ class FFCommand:
                     return output_temp_file
 
                 case "m4a":
-                    task_info.output_type = "mp3"
-                    output_temp_file = prop.output_temp_file()
-
-                    command.add(cls.get_convert_audio_command(audio_temp_file, prop.output_temp_file(), "libmp3lame"))
-                    command.add_remove([audio_temp_file], task_info.download_path)
-
-                    return output_temp_file
-                
-                case _:
-                    return output_temp_file
+                    # 只有在用户勾选了m4a_to_mp3选项时才进行转换
+                    if Config.Merge.m4a_to_mp3:
+                        # 先保存原始类型
+                        original_output_type = task_info.output_type
+                        # 设置为mp3类型
+                        task_info.output_type = "mp3"
+                        # 基于新类型生成输出文件名
+                        output_mp3_file = prop.output_temp_file()
+                        # 执行转换命令
+                        command.add(cls.get_convert_audio_command(audio_temp_file, output_mp3_file, "libmp3lame"))
+                        command.add_remove([audio_temp_file], task_info.download_path)
+                        # 返回实际生成的文件名
+                        return output_mp3_file
+                    else:
+                        # 不转换时直接返回原始音频文件
+                        return audio_temp_file
 
         command = Command()
 


### PR DESCRIPTION
解决 https://github.com/ScottSloan/Bili23-Downloader/issues/245

进行了简单测试

| 工具-设置-ffmpeg，“仅下载音频时，将m4a音频转换为mp3格式” | 工具-设置-ffmpeg，合并后保留原始文件 | 下载选项-媒体下载选项-仅勾选音频流 | 是否正常等记录                                               |
| -------------------------------------------------------- | ------------------------------------ | ---------------------------------- | ------------------------------------------------------------ |
| 不选                                                     | 否                                   | 是                                 | 正常。m4a正确命名为片子名字                                        |
| 选中                                                     | 是                                   | 是                                 | 正常。正常转换到mp3，且mp3正确命名为片子名字<br>但是保留的原始m4a没有命名，依然数字形式 |
| 无关                                                     | 是                                   | 否                                 | 正常。影片命名正确<br>原始视频、音频，按片子名字命名               |
| 无关                                                     | 否                                   | 否                                 | 正常。影片命名正确                                                 |


