### PR TITLE
【修复】有时，任务管理中，无法删除单个或者所有任务

### DIFF
--- a/src/utils/module/ffmpeg/utils.py
+++ b/src/utils/module/ffmpeg/utils.py
@@ -58,8 +58,13 @@ class FFUtils:
         temp_files = []
 
         prop = FFProp(task_info)
-
-        match StreamType(task_info.stream_type):
+        
+        try:
+            stream_type = StreamType(task_info.stream_type)
+        except ValueError:
+            stream_type = StreamType.Null
+            
+        match StreamType:
             case StreamType.Dash:
                 if "video" in task_info.download_option:
                     temp_files.append(prop.video_temp_file())


### PR DESCRIPTION
有时会报告
   raise ve_exc
ValueError: 0 is not a valid StreamType


​