### PR TITLE
修复解析页面"下载所选项目"按钮在默认勾选时未启用的问题

### DIFF
--- a/src/gui/component/parse_list/tree_view.py
+++ b/src/gui/component/parse_list/tree_view.py
@@ -57,8 +57,12 @@ class ParseTreeView(TreeView):
         self._model.root_node = root_node
         self._model.endResetModel()
 
+        # 勾选默认项并刷新视图
+        self._auto_select_by_episode_data(current_episode_data)
+
+        # 滚动定位到对应项
         self._schedule_expand_all(
-            lambda: self.locate_to_item_by_episode_data(current_episode_data)
+            lambda: self._scroll_to_episode_data(current_episode_data)
         )
 
     def _schedule_expand_all(self, callback = None):
@@ -245,7 +249,7 @@ class ParseTreeView(TreeView):
             # 选中该项
             self.setCurrentIndex(index)
 
-    def locate_to_item_by_episode_data(self, current_episode_data: tuple = None):
+    def _auto_select_by_episode_data(self, current_episode_data: tuple = None):
         # 没传入剧集数据，不做任何操作
         if not current_episode_data:
             return
@@ -253,14 +257,26 @@ class ParseTreeView(TreeView):
         key = current_episode_data[0]
         value = current_episode_data[1]
 
-        # 根据传入的剧集数据定位到对应的项目
-        all_items = self.get_all_items()
+        # 定位到对应项目并勾选
+        for item in self.get_all_items():
+            if getattr(item, key) == value:
+                item.set_checked_state(Qt.CheckState.Checked)
+                break
 
-        # 不仅滚动到该项，还要自动选中
-        for item in all_items:
+        self.update_check_state()
+
+    def _scroll_to_episode_data(self, current_episode_data: tuple = None):
+        # 没传入剧集数据，不做任何操作
+        if not current_episode_data:
+            return
+
+        key = current_episode_data[0]
+        value = current_episode_data[1]
+
+        # 滚动定位到对应项目
+        for item in self.get_all_items():
             if getattr(item, key) == value:
                 self.scroll_to_item(item)
-                item.set_checked_state(Qt.CheckState.Checked)
                 break
 
     def check_items(self, items: List[TreeItem]):


### PR DESCRIPTION
# 问题描述

在 2.11.0 版本的"解析"页面, 输入任意 bili 视频链接后, 软件会自动勾选该视频, 但右下角的 "下载所选项目" 按钮却保持灰色不可点。必须手动取消勾选再重新勾选, 按钮才会变亮。2.10.4 版本不存在此问题。

<img width="1524" height="960" alt="屏幕截图 2026-07-17 205206" src="https://github.com/user-attachments/assets/3b0d1aa9-26a7-4d0e-9a55-4f2276006c26" />

# 产生问题的原因

2.11.0 为优化大合集的解析卡顿, 把解析树的展开方式改成了分批异步展开。同时把 "自动勾选视频" 这一步也塞进了异步展开的回调里。但按钮的启用状态是在解析完成的瞬间刷新的——这时异步展开还没跑完, 按钮刷新读到的是 "未勾选", 于是判定为灰色。

异步展开跑完后虽然勾选了视频, 但这次勾选用的是直接改数据的方式, 没有发信号通知界面, 所以按钮没有被刷新, 就卡在灰色了。

# 我的修复

把一个方法拆成 "勾选" 和 "滚动" 两个方法:

- 勾选: 在数据替换 (endResetModel) 完成后立即同步执行。这一步只依赖数据树, 不需要等视图展开, 所以放同步里比较合适。勾选后主动发一次信号刷新按钮。
- 滚动定位: 仍然走异步展开的回调, 因为它依赖视图展开完成才能滚动到正确位置。