### PR TITLE
fix: 二维码登录直连被强制断开 (Error 10054)

### DIFF
--- a/src/util/download/downloader/downloader.py
+++ b/src/util/download/downloader/downloader.py
@@ -12,7 +12,7 @@ from ...common.io.file import File
 
 from ...parse.additional.worker import AdditionalParseWorker
 from ...thread.pool import GlobalThreadPoolTask
-from ...network.request import get_cookies, get_mounts, get_ssl_context
+from ...network.request import get_cookies, get_env_mounts, get_mounts, get_ssl_context
 from ...network.proxy import Proxy
 from ...thread.async_ import AsyncTask
 
@@ -668,7 +668,13 @@ class Downloader(QObject):
 
         limits = httpx.Limits(max_keepalive_connections = config.get(config.download_thread), max_connections = config.get(config.download_thread))
         transport = httpx.HTTPTransport(retries = 5, verify = ssl_context)
-        mounts = get_mounts(Proxy().get_proxies())
+
+        if config.get(config.proxy_enabled):
+            mounts = get_mounts(Proxy().get_proxies())
+        else:
+            # 未在应用内配置代理时，回退读取系统代理，避免因显式传入 transport
+            # 导致 httpx 不再读取环境变量中的代理，直连被服务器强制断开（Error 10054）。
+            mounts = get_env_mounts()
 
         headers = {
             "Referer": self.task_info.Episode.url,

--- a/src/util/network/request.py
+++ b/src/util/network/request.py
@@ -61,6 +61,48 @@ def get_mounts(proxies = None):
     else:
         return None
 
+def get_env_proxy_urls():
+    # 读取系统环境变量（及 Windows 注册表）中的代理设置，
+    # 语义与 httpx 默认的 get_environment_proxies 保持一致。
+    from urllib.request import getproxies
+
+    proxy_info = getproxies()
+
+    urls = {}
+
+    for scheme in ("http", "https", "all"):
+        if proxy_info.get(scheme):
+            hostname = proxy_info[scheme]
+
+            urls[f"{scheme}://"] = (
+                hostname if "://" in hostname else f"http://{hostname}"
+            )
+
+    for hostname in (host.strip() for host in proxy_info.get("no", "").split(",")):
+        if hostname == "*":
+            return {}
+
+        elif hostname:
+            if "://" in hostname:
+                urls[hostname] = None
+            elif hostname.lower() == "localhost":
+                urls[f"all://{hostname}"] = None
+            else:
+                urls[f"all://*{hostname}"] = None
+
+    return urls
+
+def get_env_mounts():
+    mounts = {}
+
+    for key, proxy_url in get_env_proxy_urls().items():
+        if proxy_url is None:
+            mounts[key] = None
+        else:
+            mounts[key] = httpx.HTTPTransport(proxy = httpx.Proxy(proxy_url), retries = 3, verify = get_ssl_context())
+
+    return mounts or None
+
 def _create_client():
     from .proxy import Proxy
 
@@ -70,10 +112,19 @@ def _create_client():
     if config.get(config.proxy_enabled):
         logger.info("已启用代理，类型：%s，服务器：%s:%s", config.get(config.proxy_type), config.get(config.proxy_server), config.get(config.proxy_port))
 
+        mounts = get_mounts(Proxy().get_proxies())
+    else:
+        # 未在应用内配置代理时，回退读取系统代理，避免因显式传入 transport
+        # 导致 httpx 不再读取环境变量中的代理，直连被服务器强制断开（Error 10054）。
+        mounts = get_env_mounts()
+
+        if mounts:
+            logger.info("已读取系统代理设置")
+
     return httpx.Client(
         limits = limits,
         timeout = 5,
-        mounts = get_mounts(Proxy().get_proxies()),
+        mounts = mounts,
         transport = transport,
         follow_redirects = True,
         verify = get_ssl_context()


### PR DESCRIPTION
## 问题描述

扫码登录时二维码无法加载，错误日志：

\\\
util.auth.base(at base.py:15 in on_error) 消息 win Error 10054 远程主机强迫关闭了一个现有的连接
\\\

## 根因

\util/network/request.py\ 的 \_create_client()\ 显式传入了自定义 \	ransport\。httpx 的行为是：只要显式传了 \	ransport\，就**不再读取系统代理**（\llow_env_proxies = trust_env and transport is None\）。

当用户系统配置了代理（环境变量 / Windows 注册表）时，程序会绕过代理直连 bilibili，连接被服务器强制重置，抛出 \Error 10054\，导致二维码请求失败、二维码无法生成。

已验证：直连 bilibili 100% 触发 \Error 10054\，走系统代理 100% 成功。

## 修复

- 新增 \get_env_proxy_urls()\ / \get_env_mounts()\：读取系统环境变量及 Windows 注册表中的代理设置，语义与 httpx 默认的 \get_environment_proxies\ 一致，并兼容 \NO_PROXY\。
- \_create_client()\：未在应用内配置代理时，回退读取系统代理挂载（mounts），保持自定义 transport 的 retries / 共享 SSLContext 特性。
- \util/download/downloader/downloader.py\ 的 \init_session()\ 存在同样的显式 transport 问题，一并修复。

## 测试

- Windows x64 便携版构建成功并可正常启动。
- 直连 vs 代理对比验证：修复后走系统代理请求 bilibili 登录二维码接口 100% 成功。